### PR TITLE
Adding YAML syntax highlighting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You need a repo to hold the log. Make this.
 Start your log(tasks.yaml) out looking like this:
 
 
-```
+```yaml
 ---
 task:
   name: job


### PR DESCRIPTION
Previously, there was no syntax highlighting for the example log under
"log format". Now it has pretty colors.

Signed-off-by: Matt Langbehn matthew.langbehn@gmail.com
