### PR TITLE
Added a simple example to use cron and log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ You need a repo to hold the log. Make this.
 * Clone the log repo into /opt/git/finglonger-tasks/
 * Symlink in the finglonger hook: `ln -s /opt/git/finglonger/finglonger-hook /opt/git/finglonger-tasks/.git/hooks/post-merge`
 * Set some kind of a cron job to run 'git pull' in the log git repo periodically. It will automatically run things from the log.
+  * For example, adding the following to the appropriate user's crontab would cause finglonger to run once every five minutes and log to `/var/log/finglonger.log`:
+
+        ```shell
+        */5 * * * * cd /opt/git/finglonger-tasks && echo "\n--\n$(date)\n\nPULLIN'\n--\n" >> /var/log/finglonger.log && git pull >> /var/log/finglonger.log
+        ```
 
 
 # log format


### PR DESCRIPTION
Previously, the documentation suggested using cron to schedule
finglonger poking  at stuff, but left the enduser to figure out how to
do so.

Now the documentation shows an example of using cron. The example also
redirects output to a logfile, making scheduled tasks more easily
debugable.

Signed-off-by: Matt Langbehn matthew.langbehn@gmail.com
